### PR TITLE
Close socket before attempting reconnection.

### DIFF
--- a/src/banana_websocket_client.erl
+++ b/src/banana_websocket_client.erl
@@ -415,6 +415,13 @@ handshaking(info, {Trans, _Socket, Data},
                     erlang:send_after(KA, self(), keepalive),
                     handle_successful_handshake(Remaining, Context, HState1, KA);
                 {reconnect, Interval, HState1} ->
+                    % Close the current socket before attempting reconnection
+                    case websocket_req:socket(WSReq1) of
+                        undefined -> ok;
+                        Socket ->
+                            Transport = websocket_req:transport(WSReq1),
+                            _ = (Transport#transport.mod):close(Socket)
+                    end,
                     % Allows "bailing" from handshake and reconnecting if client
                     % determines that connection is not properly established.
                     {next_state, disconnected, Context#context{handler={Handler, HState1}},


### PR DESCRIPTION
Close the current socket before attempting reconnection.

This is in the context of when Ogmios is not yet ready to serve data due to the underlying Cardano node not being fully synced.

Helps fix https://github.com/wowica/xogmios/issues/46